### PR TITLE
docs: add runnable examples

### DIFF
--- a/examples/01_word_tokenize.py
+++ b/examples/01_word_tokenize.py
@@ -1,0 +1,36 @@
+"""Example — split text into words and punctuation, with char offsets.
+
+Run::
+
+    python examples/01_word_tokenize.py
+"""
+from quebra_frases import (
+    word_tokenize,
+    char_indexed_word_tokenize,
+    span_indexed_word_tokenize,
+)
+
+
+def main() -> None:
+    text = "O Pedro comprou 2 pastéis de nata por 1,50 euros!"
+
+    # Plain tokens: words and punctuation come out as separate items.
+    print("tokens:", word_tokenize(text))
+
+    # char_indexed_* keeps the start offset of every token.
+    print("\nchar-indexed:")
+    for start, tok in char_indexed_word_tokenize(text):
+        print(f"  {start:>3}  {tok!r}")
+
+    # span_indexed_* gives (start, end) so you can slice back into the source.
+    print("\nspan-indexed (sliced back from source):")
+    for start, end, tok in span_indexed_word_tokenize(text):
+        assert text[start:end] == tok
+        print(f"  [{start:>2}:{end:<2}]  {tok!r}")
+
+    # Numbers with decimal commas and percent-style markers stay grouped.
+    print("\nnumbers:", word_tokenize("São 3,14 metros e 100% certos"))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/02_sentences_paragraphs.py
+++ b/examples/02_sentences_paragraphs.py
@@ -1,0 +1,52 @@
+"""Example — split text into sentences and paragraphs, keeping offsets.
+
+Run::
+
+    python examples/02_sentences_paragraphs.py
+"""
+from quebra_frases import (
+    sentence_tokenize,
+    span_indexed_sentence_tokenize,
+    paragraph_tokenize,
+    span_indexed_paragraph_tokenize,
+)
+
+
+def main() -> None:
+    text = (
+        "O Sr. Costa chegou a Lisboa às 9.30 da manhã. "
+        "Comprou um bilhete por 4,50 euros. "
+        "Será que apanhou o comboio? Apanhou, sim."
+    )
+
+    # Abbreviations (Sr.) and decimals (9.30) do not trigger a split.
+    print("sentences:")
+    for s in sentence_tokenize(text):
+        print(f"  - {s}")
+
+    print("\nsentence spans (sliced back from source):")
+    for start, end, s in span_indexed_sentence_tokenize(text):
+        assert text[start:end] == s
+        print(f"  [{start:>3}:{end:<3}]  {s}")
+
+    document = (
+        "Era uma vez um moinho à beira-rio.\n"
+        "O moleiro vivia ali sozinho.\n"
+        "\n"
+        "Um dia chegou um forasteiro.\n"
+        "Trazia notícias de longe."
+    )
+
+    # Blank lines separate paragraphs; lines within a block stay together.
+    paras = paragraph_tokenize(document)
+    print(f"\n{len(paras)} paragraphs:")
+    for i, p in enumerate(paras, 1):
+        print(f"  ({i}) {p.strip()!r}")
+
+    print("\nparagraph spans:")
+    for start, end, p in span_indexed_paragraph_tokenize(document):
+        print(f"  [{start:>3}:{end:<3}]  {p.strip()[:30]!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/03_whitespace_spans.py
+++ b/examples/03_whitespace_spans.py
@@ -1,0 +1,37 @@
+"""Example — whitespace-aware tokenizing and locating the gaps between words.
+
+Run::
+
+    python examples/03_whitespace_spans.py
+"""
+from quebra_frases import (
+    empty_space_tokenize,
+    span_indexed_empty_space_tokenize,
+    char_indexed_empty_space_tokenize,
+    get_empty_spans,
+)
+
+
+def main() -> None:
+    text = "isto   tem \t vários \n\t espaços   estranhos"
+
+    # Split purely on whitespace runs, no matter how wide or mixed.
+    print("tokens:", empty_space_tokenize(text))
+
+    # Span variant: exact (start, end) of every non-space run.
+    print("\nword spans (sliced back from source):")
+    for start, end, tok in span_indexed_empty_space_tokenize(text):
+        assert text[start:end] == tok
+        print(f"  [{start:>2}:{end:<2}]  {tok!r}")
+
+    # char_indexed_* drops the end offset, keeping just the start.
+    print("\nchar-indexed:", char_indexed_empty_space_tokenize(text))
+
+    # get_empty_spans is the inverse view: the whitespace gaps themselves.
+    print("\nwhitespace gaps:")
+    for start, end, gap in get_empty_spans(text):
+        print(f"  [{start:>2}:{end:<2}]  {gap!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/04_chunking.py
+++ b/examples/04_chunking.py
@@ -1,0 +1,34 @@
+"""Example — split on custom delimiters and locate the pieces in the source.
+
+Run::
+
+    python examples/04_chunking.py
+"""
+from quebra_frases import chunk, chunk_list, find_spans, word_tokenize
+
+
+def main() -> None:
+    text = "ligar a luz; baixar as persianas, e tocar música"
+
+    # chunk() splits on any of the given delimiter strings, stripped by default.
+    print("chunks:", chunk(text, [";", ","]))
+
+    # strip=False keeps the delimiters and surrounding whitespace as tokens.
+    print("\nraw (strip=False):", chunk(text, [";", ","], strip=False))
+
+    # chunk_list() groups an already-tokenized list, dropping the delimiters.
+    tokens = word_tokenize("acende a luz e toca uma canção")
+    groups = chunk_list(tokens, ["e"])
+    print("\ntoken groups around 'e':", groups)
+
+    # find_spans() returns (start, end, text) for delimiter pieces present
+    # in the sample set, so you can map matches back onto the source.
+    text2 = "azul,verde,azul,vermelho"
+    print("\nspans of known colours:")
+    for start, end, piece in find_spans(text2, ["azul", "verde"]):
+        assert text2[start:end] == piece
+        print(f"  [{start:>2}:{end:<2}]  {piece!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/05_compare_samples.py
+++ b/examples/05_compare_samples.py
@@ -1,0 +1,40 @@
+"""Example — compare several utterances to find shared and distinctive parts.
+
+Run::
+
+    python examples/05_compare_samples.py
+"""
+from quebra_frases import (
+    get_common_tokens,
+    get_uncommon_tokens,
+    get_exclusive_tokens,
+    get_common_chunks,
+    get_uncommon_chunks,
+)
+
+
+def main() -> None:
+    samples = [
+        "qual é a temperatura na cozinha",
+        "qual é a temperatura na sala",
+        "qual é a temperatura no quarto",
+    ]
+
+    # Tokens that appear in every sample.
+    print("common tokens:", sorted(get_common_tokens(samples)))
+
+    # Tokens missing from at least one sample.
+    print("uncommon tokens:", sorted(get_uncommon_tokens(samples)))
+
+    # Tokens unique to a single sample (appear nowhere else).
+    print("exclusive tokens:", sorted(get_exclusive_tokens(samples)))
+
+    # Chunks are word-runs grouped by the comparison: the shared scaffold...
+    print("\ncommon chunks:", sorted(get_common_chunks(samples)))
+
+    # ...versus the parts that vary between utterances.
+    print("uncommon chunks:", sorted(get_uncommon_chunks(samples)))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a numbered `examples/` directory with runnable scripts covering the public API:

- `01_word_tokenize.py` — word/punctuation tokenizing with char and span offsets
- `02_sentences_paragraphs.py` — sentence and paragraph splitting with offsets
- `03_whitespace_spans.py` — whitespace-aware tokenizing and gap spans
- `04_chunking.py` — delimiter chunking, list grouping, and `find_spans`
- `05_compare_samples.py` — common, uncommon, and exclusive tokens and chunks across samples

Each script runs standalone with inline Portuguese sample text and prints illustrative output. Examples use only the library's public API plus the standard library.